### PR TITLE
Bump version to 2.0.0-alpha.0 as a baseline to build 2.x changes on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@farmos.org/farmos-map",
-  "version": "v1.4.2",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@farmos.org/farmos-map",
-      "version": "v1.4.2",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@farmos.org/farmos-olgm": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmos.org/farmos-map",
-  "version": "v1.4.2",
+  "version": "2.0.0-alpha.0",
   "description": "OpenLayers map used in farmOS.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
**Why?** Follow the NPM recommended semantic versioning conventions.

* https://docs.npmjs.com/about-semantic-versioning
* https://github.com/npm/node-semver#prerelease-identifiers